### PR TITLE
Replace old URLs in career/joblinks.md

### DIFF
--- a/career/joblinks.md
+++ b/career/joblinks.md
@@ -5,9 +5,9 @@ subtitle: Other places to look for oceanography jobs
 ---
 
 ## Mailing lists
-* The [met-jobs mailing list](https://www.lists.rdg.ac.uk/mailman/listinfo/met-jobs) often advertises positions in oceanography, meteorology and climate.
+* The [met-jobs mailing list](https://maillists.reading.ac.uk/scripts/wa-READING.exe?A0=MET-JOBS) often advertises positions in oceanography, meteorology and climate.
 * The [es_jobs_net mailing list](https://mailman.ucar.edu/mailman/listinfo/es_jobs_net) is similar to the met-jobs list.
-* The [climlist mailing list](http://climlist.wku.edu/) often advertises positions in climate research and oceanography.
+* The [climlist mailing list](mailto:climlist-subscribe@lists.wku.edu) often advertises positions in climate research and oceanography.
 * The [cryolist mailing list](http://cryolist.org/) advertises positions related to ice, which often includes ice-ocean interactions (sea ice or land ice).
 
 ## Websites
@@ -19,8 +19,5 @@ subtitle: Other places to look for oceanography jobs
 
 Don't forget to check the websites of individual institutions and universities since some ads might not reach the lists above.
 
-<!--
-Some examples include:
-* Job openings at [Woods Hole Oceanographic Institution](https://allcareers-whoi.icims.com/jobs/)
-* Job openings at [Scripps Institution of Oceanography](https://scripps.ucsd.edu/portal/jobs)
--->
+- The [Scripps Institution of Oceanography](https://scripps.ucsd.edu/portal/jobs)
+


### PR DESCRIPTION
This PR fixes #6

After stumbling upon two broken links, I searched for the updated ones and found that for wku.edu, we have a general list for all the mailing lists of the university, instead of an individual link for our _climlist_, so I replaced it with the subscription e-mail...

Also, I uncommented a link that is perfectly working and fits the purpose, it should be available to the general visitors, the other one was deleted because it wasn't working and I couldn't find a replacement.